### PR TITLE
Fix Homebrew builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 xcuserdata
 project.xcworkspace
 bin/dark-mode
+.build/

--- a/build
+++ b/build
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-xcodebuild archive -derivedDataPath $(mktemp -d) -scheme dark-mode
+set -x
+
+xcodebuild archive -derivedDataPath $(mktemp -d) -scheme dark-mode OBJROOT=.build SYMROOT=.build
+cp .build/Release/dark-mode bin/dark-mode
+

--- a/build
+++ b/build
@@ -4,4 +4,3 @@ set -x
 
 xcodebuild archive -derivedDataPath $(mktemp -d) -scheme dark-mode OBJROOT=.build SYMROOT=.build
 cp .build/Release/dark-mode bin/dark-mode
-

--- a/dark-mode.xcodeproj/project.pbxproj
+++ b/dark-mode.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 				E3A310621E4503E500D314DD /* Sources */,
 				E3A310631E4503E500D314DD /* Frameworks */,
 				E3A310641E4503E500D314DD /* CopyFiles */,
-				E3A310701E45076C00D314DD /* Run Script */,
 			);
 			buildRules = (
 			);
@@ -182,24 +181,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		E3A310701E45076C00D314DD /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = "mkdir -p \"bin\" && cp \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_NAME}\" \"bin/${EXECUTABLE_NAME}\"";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		E3A310621E4503E500D314DD /* Sources */ = {

--- a/readme.md
+++ b/readme.md
@@ -41,9 +41,9 @@ $ dark-mode --help
 
 ## Build
 
-Run `./build`, binary will be exported to ./bin/dark-mode.
+Run `./build`. The binary can be found at `./bin/dark-mode`.
 
-Building in Xcode works, but does not export binary.
+Building in Xcode works, but it does not export a binary.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,9 @@ $ dark-mode --help
 
 ## Build
 
-Run `./build` or build in Xcode.
+Run `./build`, binary will be exported to ./bin/dark-mode.
+
+Building in Xcode works, but does not export binary.
 
 ## Related
 


### PR DESCRIPTION
This moves the copying of build product to ./bin/dark-mode from a build phase to the ./build script. This is done to ensure we never copy a non-codesigned binary to ./bin - which is what seems to be the cause of #19.

This would work even without removing the build phase, as the copy from ./build will simply overwrite it. I'm not sure the build phase copy is really useful for other things than release though, and it's a bit quirky - basically it seems to never be codesigned on first build (e.g. after a "Clean build folder" + "build"), but it will then be codesinged on subsequent builds.

If you would like me to update the PR to keep the build phase in, let me know and i'll fix that.

Fixes #19